### PR TITLE
Replace starkscan.co references with voyager.online

### DIFF
--- a/examples/ios-app/SessionAccountApp/README.md
+++ b/examples/ios-app/SessionAccountApp/README.md
@@ -41,7 +41,7 @@ A complete iOS app demonstrating how to create and use Cartridge Controller Sess
 ### Status Tab
 - Session status and info
 - Active policies list
-- Last transaction details with Starkscan link
+- Last transaction details with Voyager link
 - Configuration details
 
 ## How It Works
@@ -69,7 +69,7 @@ A complete iOS app demonstrating how to create and use Cartridge Controller Sess
 - View session status
 - Check active policies
 - Copy transaction hashes
-- Open transactions in Starkscan
+- Open transactions in Voyager
 
 ## Building the App
 
@@ -149,7 +149,7 @@ SessionAccountApp/
 3. **Verify**:
    - Go to Status tab
    - See transaction hash
-   - Click "View on Starkscan"
+   - Click "View on Voyager"
 
 ### Adding Custom Policies
 
@@ -241,7 +241,7 @@ Currently configured for **Sepolia testnet**. To switch networks:
 - [Cartridge Controller Docs](https://docs.cartridge.gg/controller/overview)
 - [Session Management](https://docs.cartridge.gg/controller/sessions)
 - [Starknet Docs](https://docs.starknet.io)
-- [Starkscan Explorer](https://starkscan.co)
+- [Voyager Explorer](https://voyager.online)
 
 ## License
 

--- a/examples/ios-app/SessionAccountApp/Views/StatusView.swift
+++ b/examples/ios-app/SessionAccountApp/Views/StatusView.swift
@@ -109,11 +109,11 @@ struct StatusView: View {
                         }
                         
                         Button {
-                            if let url = URL(string: "https://sepolia.starkscan.co/tx/\(txHash)") {
+                            if let url = URL(string: "https://sepolia.voyager.online/tx/\(txHash)") {
                                 UIApplication.shared.open(url)
                             }
                         } label: {
-                            Label("View on Starkscan", systemImage: "safari")
+                            Label("View on Voyager", systemImage: "safari")
                         }
                     } header: {
                         Text("Last Transaction")

--- a/examples/ios-app/SessionAccountApp/controller/controller/Views/StatusView.swift
+++ b/examples/ios-app/SessionAccountApp/controller/controller/Views/StatusView.swift
@@ -194,11 +194,11 @@ struct StatusView: View {
                         }
                         
                         Button {
-                            if let url = URL(string: "https://sepolia.starkscan.co/tx/\(txHash)") {
+                            if let url = URL(string: "https://sepolia.voyager.online/tx/\(txHash)") {
                                 UIApplication.shared.open(url)
                             }
                         } label: {
-                            Label("View on Starkscan", systemImage: "safari")
+                            Label("View on Voyager", systemImage: "safari")
                         }
                     } header: {
                         Text("Last Transaction")

--- a/examples/react-native/app/index.tsx
+++ b/examples/react-native/app/index.tsx
@@ -169,10 +169,10 @@ export default function App() {
             <TouchableOpacity
               style={styles.linkButton}
               onPress={() =>
-                Linking.openURL(`https://sepolia.starkscan.co/tx/${currentTransaction.hash}`)
+                Linking.openURL(`https://sepolia.voyager.online/tx/${currentTransaction.hash}`)
               }
             >
-              <Text style={styles.linkButtonText}>View on Starkscan</Text>
+              <Text style={styles.linkButtonText}>View on Voyager</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={styles.dismissButton}

--- a/examples/swift/session_account.swift
+++ b/examples/swift/session_account.swift
@@ -168,7 +168,7 @@ func sessionAccountExample() {
         let txHash = try session.execute(calls: [call])
         printSuccess("Transaction executed successfully!")
         printInfo("📝 Transaction hash: \(txHash)")
-        printInfo("🔍 View on Starkscan: https://sepolia.starkscan.co/tx/\(txHash)")
+        printInfo("🔍 View on Voyager: https://sepolia.voyager.online/tx/\(txHash)")
         
     } catch {
         printError("Transaction execution failed: \(error)")


### PR DESCRIPTION
## Summary
- Updated explorer URLs and link text in Swift examples
- Updated explorer URLs and link text in React Native examples
- Updated README documentation references

### Files changed:
- `examples/swift/session_account.swift`
- `examples/react-native/app/index.tsx`
- `examples/ios-app/SessionAccountApp/Views/StatusView.swift`
- `examples/ios-app/SessionAccountApp/controller/controller/Views/StatusView.swift`
- `examples/ios-app/SessionAccountApp/README.md`

## Test plan
- Verify explorer links work correctly in iOS app
- Verify explorer links work correctly in React Native app
- Verify README links are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)