### PR TITLE
fix(session): canonicalize policy ordering for registration URL and session hash

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -15,7 +15,7 @@ use url::Url;
 
 use crate::error::ControllerError;
 use crate::runtime::RUNTIME;
-use crate::types::{Call, ControllerFieldElement, SessionPolicies};
+use crate::types::{canonicalize_session_policies, Call, ControllerFieldElement, SessionPolicies};
 
 #[derive(Serialize)]
 struct SessionRegistrationPolicyPayload {
@@ -43,14 +43,14 @@ fn build_session_registration_long_url(
     keychain_url: &str,
     preset: Option<&str>,
 ) -> Result<String, ControllerError> {
-    let policy_payload: Vec<SessionRegistrationPolicyPayload> = policies
-        .policies
-        .iter()
-        .map(|policy| SessionRegistrationPolicyPayload {
-            target: policy.contract_address.0.clone(),
-            method: policy.entrypoint.clone(),
-        })
-        .collect();
+    let policy_payload: Vec<SessionRegistrationPolicyPayload> =
+        canonicalize_session_policies(policies)?
+            .iter()
+            .map(|policy| SessionRegistrationPolicyPayload {
+                target: policy.contract_address_hex.clone(),
+                method: policy.entrypoint.clone(),
+            })
+            .collect();
 
     let policies_json = serde_json::to_string(&policy_payload).map_err(|e| {
         ControllerError::InvalidInput(format!("Failed to serialize session policies: {}", e))
@@ -579,7 +579,10 @@ mod tests {
         );
         assert_eq!(
             params.get("policies"),
-            Some(&r#"[{"target":"0xabc","method":"transfer"}]"#.to_string())
+            Some(
+                &r#"[{"target":"0x0000000000000000000000000000000000000000000000000000000000000abc","method":"transfer"}]"#
+                    .to_string()
+            )
         );
         assert_eq!(params.get("preset"), None);
     }
@@ -643,5 +646,49 @@ mod tests {
         let parsed = parse_shorten_response(StatusCode::OK, body, "api.cartridge.gg")
             .expect("parse response");
         assert_eq!(parsed, "https://api.cartridge.gg/s/a1B2c3D4e5");
+    }
+
+    #[test]
+    fn canonicalizes_policy_order_in_registration_url() {
+        let policies = SessionPolicies {
+            policies: vec![
+                crate::types::SessionPolicy {
+                    contract_address: ControllerFieldElement("0x10".to_string()),
+                    entrypoint: "zeta".to_string(),
+                },
+                crate::types::SessionPolicy {
+                    contract_address: ControllerFieldElement("0x2".to_string()),
+                    entrypoint: "beta".to_string(),
+                },
+                crate::types::SessionPolicy {
+                    contract_address: ControllerFieldElement("0x2".to_string()),
+                    entrypoint: "alpha".to_string(),
+                },
+            ],
+            max_fee: ControllerFieldElement("0x1".to_string()),
+        };
+
+        let url = build_session_registration_long_url(
+            "0x123",
+            &policies,
+            "https://api.cartridge.gg/x/starknet/sepolia",
+            "https://x.cartridge.gg",
+            None,
+        )
+        .expect("build URL");
+
+        let parsed = Url::parse(&url).expect("parse url");
+        let params: HashMap<String, String> = parsed
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+
+        assert_eq!(
+            params.get("policies"),
+            Some(
+                &r#"[{"target":"0x0000000000000000000000000000000000000000000000000000000000000002","method":"alpha"},{"target":"0x0000000000000000000000000000000000000000000000000000000000000002","method":"beta"},{"target":"0x0000000000000000000000000000000000000000000000000000000000000010","method":"zeta"}]"#
+                    .to_string()
+            )
+        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -62,21 +62,112 @@ pub struct SessionPolicies {
     pub max_fee: ControllerFieldElement,
 }
 
+pub(crate) struct CanonicalSessionPolicy {
+    pub(crate) contract_address: Felt,
+    pub(crate) contract_address_hex: String,
+    pub(crate) entrypoint: String,
+}
+
+pub(crate) fn canonicalize_session_policies(
+    policies: &SessionPolicies,
+) -> Result<Vec<CanonicalSessionPolicy>, ControllerError> {
+    let mut entries = policies
+        .policies
+        .iter()
+        .map(|policy| {
+            let contract_address = Felt::from_hex(&policy.contract_address.0)
+                .map_err(|e| ControllerError::InvalidInput(e.to_string()))?;
+
+            Ok(CanonicalSessionPolicy {
+                contract_address,
+                contract_address_hex: format!("0x{contract_address:064x}"),
+                entrypoint: policy.entrypoint.clone(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Match controller canonical ordering: address, then entrypoint.
+    entries.sort_by(|a, b| {
+        a.contract_address_hex
+            .cmp(&b.contract_address_hex)
+            .then_with(|| {
+                a.entrypoint
+                    .to_ascii_lowercase()
+                    .cmp(&b.entrypoint.to_ascii_lowercase())
+            })
+            .then_with(|| a.entrypoint.cmp(&b.entrypoint))
+    });
+
+    Ok(entries)
+}
+
 impl TryFrom<&SessionPolicies> for Vec<account_sdk::account::session::policy::Policy> {
     type Error = ControllerError;
 
     fn try_from(policies: &SessionPolicies) -> Result<Self, Self::Error> {
         let mut result = Vec::new();
-        for policy in &policies.policies {
-            let contract_address = Felt::from_hex(&policy.contract_address.0)
-                .map_err(|e| ControllerError::InvalidInput(e.to_string()))?;
-
+        for policy in canonicalize_session_policies(policies)? {
             let selector = starknet::core::utils::get_selector_from_name(&policy.entrypoint)
                 .map_err(|e| ControllerError::InvalidInput(e.to_string()))?;
-            let sdk_policy =
-                account_sdk::account::session::policy::Policy::new_call(contract_address, selector);
+            let sdk_policy = account_sdk::account::session::policy::Policy::new_call(
+                policy.contract_address,
+                selector,
+            );
             result.push(sdk_policy);
         }
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalize_session_policies_sorts_by_padded_address_then_method() {
+        let policies = SessionPolicies {
+            policies: vec![
+                SessionPolicy {
+                    contract_address: ControllerFieldElement("0x10".to_string()),
+                    entrypoint: "zeta".to_string(),
+                },
+                SessionPolicy {
+                    contract_address: ControllerFieldElement("0x2".to_string()),
+                    entrypoint: "alpha".to_string(),
+                },
+                SessionPolicy {
+                    contract_address: ControllerFieldElement("0x2".to_string()),
+                    entrypoint: "beta".to_string(),
+                },
+            ],
+            max_fee: ControllerFieldElement("0x0".to_string()),
+        };
+
+        let canonical = canonicalize_session_policies(&policies).expect("canonicalize");
+        let ordered = canonical
+            .iter()
+            .map(|p| (p.contract_address_hex.clone(), p.entrypoint.clone()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            ordered,
+            vec![
+                (
+                    "0x0000000000000000000000000000000000000000000000000000000000000002"
+                        .to_string(),
+                    "alpha".to_string()
+                ),
+                (
+                    "0x0000000000000000000000000000000000000000000000000000000000000002"
+                        .to_string(),
+                    "beta".to_string()
+                ),
+                (
+                    "0x0000000000000000000000000000000000000000000000000000000000000010"
+                        .to_string(),
+                    "zeta".to_string()
+                ),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Summary:
- Canonicalize session policies before building the policies query parameter for session registration URLs.
- Use the same canonical ordering when converting SessionPolicies to SDK policies for local session hash construction.
- Normalize contract addresses to zero-padded lowercase hex and sort by address then entrypoint.

Why:
Equivalent policy sets serialized in different orders can cause session/not-registered due hash mismatch.

Validation:
- cargo fmt
- cargo test session::tests:: -- --nocapture
- cargo clippy