### PR TITLE
ci(release): dispatch-driven versioned release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,48 +4,118 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g., v1.0.0)'
+        description: 'Release version tag (example: v1.2.3)'
         required: true
         type: string
-  push:
-    tags:
-      - 'v*.*.*'
+      prerelease:
+        description: 'Mark as pre-release'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+concurrency:
+  group: release-${{ github.event.inputs.version }}
+  cancel-in-progress: false
+
 jobs:
-  create-release:
-    name: Create Release
+  prepare-release:
+    name: Prepare Release
     runs-on: ubuntu-latest
     outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      version: ${{ steps.get_version.outputs.version }}
+      version: ${{ steps.prepare.outputs.version }}
+      tag: ${{ steps.prepare.outputs.tag }}
+      target_sha: ${{ steps.prepare.outputs.target_sha }}
     steps:
-      - name: Get version
-        id: get_version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
         with:
-          tag_name: ${{ steps.get_version.outputs.version }}
-          release_name: Release ${{ steps.get_version.outputs.version }}
-          draft: false
-          prerelease: false
+          fetch-depth: 0
 
-  build-apple:
-    name: Build Apple Platforms
-    needs: create-release
+      - name: Validate, bump versions, tag and create draft release
+        id: prepare
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          set -euo pipefail
+
+          if ! [[ "$INPUT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version format: $INPUT_VERSION"
+            echo "Expected: v1.2.3 (optionally with prerelease suffix)"
+            exit 1
+          fi
+
+          VERSION="$INPUT_VERSION"
+          VERSION_NUMBER="${VERSION#v}"
+
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag already exists locally: $VERSION"
+            exit 1
+          fi
+
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release already exists: $VERSION"
+            exit 1
+          fi
+
+          awk -v ver="$VERSION_NUMBER" '
+            BEGIN { in_pkg = 0; done = 0 }
+            /^\[package\]$/ { in_pkg = 1 }
+            /^\[/ && $0 != "[package]" && in_pkg { in_pkg = 0 }
+            in_pkg && /^version = "/ && !done {
+              print "version = \"" ver "\""
+              done = 1
+              next
+            }
+            { print }
+          ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+
+          awk -v ver="$VERSION_NUMBER" '
+            BEGIN { in_project = 0; done = 0 }
+            /^\[project\]$/ { in_project = 1 }
+            /^\[/ && $0 != "[project]" && in_project { in_project = 0 }
+            in_project && /^version = "/ && !done {
+              print "version = \"" ver "\""
+              done = 1
+              next
+            }
+            { print }
+          ' bindings/py/pyproject.toml > bindings/py/pyproject.toml.tmp && mv bindings/py/pyproject.toml.tmp bindings/py/pyproject.toml
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet -- Cargo.toml bindings/py/pyproject.toml; then
+            git add Cargo.toml bindings/py/pyproject.toml
+            git commit -m "chore(release): bump version to $VERSION"
+            git push origin HEAD:${{ github.ref_name }}
+          fi
+
+          TARGET_SHA="$(git rev-parse HEAD)"
+
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+
+          gh release create "$VERSION" \
+            --title "Release $VERSION" \
+            --target "$TARGET_SHA" \
+            --draft \
+            $([ "$INPUT_PRERELEASE" = "true" ] && echo "--prerelease")
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "target_sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+
+  build-macos:
+    name: Build macOS (${{ matrix.name }})
+    needs: prepare-release
     runs-on: macos-latest
     strategy:
       matrix:
@@ -54,87 +124,89 @@ jobs:
             name: macos-arm64
           - target: x86_64-apple-darwin
             name: macos-x86_64
-          - target: aarch64-apple-ios
-            name: ios-arm64
-          - target: aarch64-apple-ios-sim
-            name: ios-simulator-arm64
     steps:
       - uses: actions/checkout@v4
-      
+        with:
+          ref: ${{ needs.prepare-release.outputs.tag }}
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
-      
+
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
-      
-      - name: Package binary
+
+      - name: Package artifacts
         run: |
           cd target/${{ matrix.target }}/release
           tar czf controller_uniffi-${{ matrix.name }}.tar.gz libcontroller_uniffi.a libcontroller_uniffi.dylib
           mv controller_uniffi-${{ matrix.name }}.tar.gz ../../../
-      
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./controller_uniffi-${{ matrix.name }}.tar.gz
-          asset_name: controller_uniffi-${{ matrix.name }}.tar.gz
-          asset_content_type: application/gzip
 
-  build-xcframework:
-    name: Build XCFramework
-    needs: create-release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.name }}
+          path: controller_uniffi-${{ matrix.name }}.tar.gz
+          if-no-files-found: error
+
+  build-ios:
+    name: Build iOS Libraries
+    needs: prepare-release
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      
+        with:
+          ref: ${{ needs.prepare-release.outputs.tag }}
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-ios,aarch64-apple-ios-sim
-      
-      - name: Cache cargo registry
-        uses: actions/cache@v4
+
+      - name: Build iOS static libs
+        run: |
+          cargo build --release --target aarch64-apple-ios
+          cargo build --release --target aarch64-apple-ios-sim
+
+      - name: Package iOS libraries
+        run: |
+          mkdir -p controller_uniffi_ios_libs/ios-arm64 controller_uniffi_ios_libs/ios-sim-arm64
+          cp target/aarch64-apple-ios/release/libcontroller_uniffi.a controller_uniffi_ios_libs/ios-arm64/
+          cp target/aarch64-apple-ios-sim/release/libcontroller_uniffi.a controller_uniffi_ios_libs/ios-sim-arm64/
+          tar czf controller_uniffi-ios-libs.tar.gz controller_uniffi_ios_libs
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo index
-        uses: actions/cache@v4
+          name: release-ios-libs
+          path: controller_uniffi-ios-libs.tar.gz
+          if-no-files-found: error
+
+  build-xcframework:
+    name: Build XCFramework
+    needs: prepare-release
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
         with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      
+          ref: ${{ needs.prepare-release.outputs.tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+
       - name: Build iOS targets
         run: |
           cargo build --release --target aarch64-apple-ios
           cargo build --release --target aarch64-apple-ios-sim
-      
+
       - name: Generate Swift bindings
-        run: ./scripts/build_swift.sh
-      
+        run: |
+          cargo build --release
+          cargo run --release --bin uniffi-bindgen-swift -- --headers --modulemap --xcframework
+
       - name: Create XCFramework
         run: |
           rm -rf target/controller_uniffi.xcframework
@@ -142,7 +214,7 @@ jobs:
             -library target/aarch64-apple-ios/release/libcontroller_uniffi.a \
             -library target/aarch64-apple-ios-sim/release/libcontroller_uniffi.a \
             -output target/controller_uniffi.xcframework
-      
+
       - name: Package XCFramework with Swift bindings
         run: |
           mkdir -p controller_uniffi_ios
@@ -151,20 +223,17 @@ jobs:
           cp bindings/swift/controller_uniffiFFI.h controller_uniffi_ios/
           cp bindings/swift/controller_uniffi.modulemap controller_uniffi_ios/
           tar czf controller_uniffi_ios.tar.gz controller_uniffi_ios
-      
-      - name: Upload XCFramework
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./controller_uniffi_ios.tar.gz
-          asset_name: controller_uniffi_ios.tar.gz
-          asset_content_type: application/gzip
+          name: release-ios-xcframework
+          path: controller_uniffi_ios.tar.gz
+          if-no-files-found: error
 
   build-linux:
-    name: Build Linux
-    needs: create-release
+    name: Build Linux (${{ matrix.name }})
+    needs: prepare-release
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -175,106 +244,102 @@ jobs:
             name: linux-aarch64
     steps:
       - uses: actions/checkout@v4
-      
+        with:
+          ref: ${{ needs.prepare-release.outputs.tag }}
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      
+
       - name: Install cross
         run: cargo install cross
-      
+
       - name: Build
         run: cross build --release --target ${{ matrix.target }}
-      
-      - name: Package binary
+
+      - name: Package artifacts
         run: |
           cd target/${{ matrix.target }}/release
           tar czf controller_uniffi-${{ matrix.name }}.tar.gz libcontroller_uniffi.so libcontroller_uniffi.a
           mv controller_uniffi-${{ matrix.name }}.tar.gz ../../../
-      
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./controller_uniffi-${{ matrix.name }}.tar.gz
-          asset_name: controller_uniffi-${{ matrix.name }}.tar.gz
-          asset_content_type: application/gzip
+          name: release-${{ matrix.name }}
+          path: controller_uniffi-${{ matrix.name }}.tar.gz
+          if-no-files-found: error
 
   build-bindings:
     name: Build Language Bindings
-    needs: create-release
+    needs: prepare-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+        with:
+          ref: ${{ needs.prepare-release.outputs.tag }}
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Build library
-        run: cargo build --release
-      
+
       - name: Generate all bindings
         run: |
-          ./scripts/build_swift.sh
-          ./scripts/build_kotlin.sh
-          ./scripts/build_python.sh
-          ./scripts/build_cpp.sh
-      
+          cargo build --release
+          cargo run --release --bin uniffi-bindgen-swift -- --headers --modulemap
+          cargo run --release --bin uniffi-bindgen-kotlin
+          cargo run --release --bin uniffi-bindgen-python
+          cargo run --release --bin uniffi-bindgen-cpp
+
       - name: Package bindings
         run: |
           mkdir -p controller_uniffi_bindings
           cp -r bindings/* controller_uniffi_bindings/
           tar czf controller_uniffi_bindings.tar.gz controller_uniffi_bindings
-      
-      - name: Upload Bindings
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./controller_uniffi_bindings.tar.gz
-          asset_name: controller_uniffi_bindings.tar.gz
-          asset_content_type: application/gzip
 
-  publish-checksums:
-    name: Publish Checksums
-    needs: [create-release, build-apple, build-xcframework, build-linux, build-bindings]
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-bindings
+          path: controller_uniffi_bindings.tar.gz
+          if-no-files-found: error
+
+  publish-release:
+    name: Publish Release Assets
     runs-on: ubuntu-latest
+    needs:
+      - prepare-release
+      - build-macos
+      - build-ios
+      - build-xcframework
+      - build-linux
+      - build-bindings
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v3
-      
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
       - name: Generate checksums
         run: |
-          echo "# Release Checksums" > CHECKSUMS.txt
-          echo "" >> CHECKSUMS.txt
-          for file in *.tar.gz; do
-            if [ -f "$file" ]; then
-              sha256sum "$file" >> CHECKSUMS.txt
-            fi
-          done
-      
-      - name: Upload Checksums
-        uses: actions/upload-release-asset@v1
+          set -euo pipefail
+          cd release-assets
+          ls -lah
+          sha256sum *.tar.gz > CHECKSUMS.txt
+
+      - name: Upload assets to GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./CHECKSUMS.txt
-          asset_name: CHECKSUMS.txt
-          asset_content_type: text/plain
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" release-assets/*.tar.gz release-assets/CHECKSUMS.txt --clobber
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" --draft=false --latest --title "Release $TAG"


### PR DESCRIPTION
Summary:
- Replace deprecated release actions with a dispatch-driven pipeline using gh CLI.
- Add workflow_dispatch inputs for version and prerelease.
- Bump release versions in Cargo.toml and bindings/py/pyproject.toml in prepare step, commit, tag, and create draft release.
- Build and publish macOS, iOS libs, iOS XCFramework, Linux, and language bindings artifacts.
- Upload all assets plus CHECKSUMS.txt, then publish the release.

Important fixes:
- Stop using scripts/build_cpp.sh in CI release flow and generate bindings directly via cargo run --bin commands.
- Generate Swift modulemap explicitly with --modulemap --xcframework so XCFramework packaging does not fail.
- Ensure artifact upload fails if expected files are missing.