### PR TITLE
chore(skills): add controller.c development skill

### DIFF
--- a/.agents/skills/controller-c-development/SKILL.md
+++ b/.agents/skills/controller-c-development/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: controller-c-development
+description: Contributor workflow for cartridge-gg/controller.c. Use when implementing or reviewing UniFFI-based multi-language bindings, generated artifacts, and Rust/script validation in this repository.
+---
+
+# Controller C Development
+
+Use this skill to update `cartridge-gg/controller.c` bindings safely across supported languages.
+
+## Core Workflow
+
+1. Build the Rust core first:
+   - `cargo build --release`
+2. Regenerate only affected bindings:
+   - `./scripts/build_python.sh`
+   - `./scripts/build_swift.sh`
+   - `./scripts/build_kotlin.sh`
+   - `./scripts/build_cpp.sh`
+   - `./scripts/build_csharp.sh`
+   - `./scripts/build_go.sh`
+3. Run repository checks:
+   - `./scripts/fmt.sh`
+   - `./scripts/clippy.sh`
+   - `./scripts/test.sh`
+4. Use `./scripts/check.sh` before PR for a consolidated pass.
+
+## PR Checklist
+
+- Keep generated binding changes synchronized with Rust API updates.
+- Call out language targets regenerated in the PR body.
+- Include full validation command list and outcomes.

--- a/.agents/skills/controller-c-development/agents/openai.yaml
+++ b/.agents/skills/controller-c-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Controller C Development"
+  short_description: "Contributor workflow for cartridge-gg/controller.c"
+  default_prompt: "Use $controller-c-development to implement and validate changes in controller.c."


### PR DESCRIPTION
## Summary
- add a repository-specific development skill at `.agents/skills/controller-c-development`
- include `agents/openai.yaml` metadata for discoverability and default invocation

## Validation
- `/tmp/skillcreator-venv/bin/python /Users/nasr/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/controller-c-development`